### PR TITLE
Enhance UI and clipboard features

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -2258,5 +2258,18 @@ namespace LiuYun
         private const uint SWP_NOACTIVATE = 0x0010;
         private static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
         private static readonly IntPtr HWND_NOTOPMOST = new IntPtr(-2);
+
+        private long _clipboardMonitorSuppressedUntilTicks;
+
+        public void SuppressClipboardMonitorFor(TimeSpan duration)
+        {
+            long suppressionUntil = DateTime.UtcNow.Add(duration).Ticks;
+            Interlocked.Exchange(ref _clipboardMonitorSuppressedUntilTicks, suppressionUntil);
+        }
+
+        public bool IsClipboardMonitorSuppressed()
+        {
+            return DateTime.UtcNow.Ticks < Interlocked.Read(ref _clipboardMonitorSuppressedUntilTicks);
+        }
     }
 }

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -43,7 +43,7 @@ namespace LiuYun
         private const int ActiveWindowActivationRetries = 4;
         private const float WindowAnimationOffset = 12f;
         private const int ClipboardPreloadLimit = 300;
-        private const int CursorPlacementOffsetPx = 8;
+        public const int CursorPlacementOffsetPx = 8;
         private const string StartupLaunchArgument = "--startup";
         private const string SingleInstanceMutexName = @"Local\LiuYun.SingleInstance.Mutex";
         private const string SingleInstanceActivationEventName = @"Local\LiuYun.SingleInstance.Activate";

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -124,7 +124,7 @@ namespace LiuYun
             {
                 HideWindowForStartupLaunch();
             }
-            InitializeTrayIcon();
+            FireAndForget(InitializeTrayIconAsync(), nameof(InitializeTrayIconAsync));
             StartSingleInstanceActivationListener();
 
             _backgroundTaskQueue = new BackgroundTaskQueue(capacity: 1024, workerCount: 3);
@@ -454,7 +454,7 @@ namespace LiuYun
 
         public static Window? MainWindow => ((App)Current).m_window;
 
-        private void InitializeTrayIcon()
+        private async Task InitializeTrayIconAsync()
         {
             if (m_window is null)
             {
@@ -476,6 +476,69 @@ namespace LiuYun
                 {
                     ExitApplication();
                 };
+                service.ToggleStartupRequested += async (_, __) =>
+                {
+                    try
+                    {
+                        var startupService = new StartupService();
+                        var state = await startupService.GetStateAsync();
+                        StartupStateInfo newState;
+                        if (state.IsEnabled)
+                        {
+                            newState = await startupService.DisableAsync();
+                        }
+                        else
+                        {
+                            newState = await startupService.EnableAsync();
+                        }
+
+                        // Update menu checked state based on resulting state
+                        service.SetStartupChecked(newState.IsEnabled);
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Toggle startup failed: {ex}");
+                    }
+                };
+                service.ClearHistoryRequested += async (_, __) =>
+                {
+                    try
+                    {
+                        if (ClipboardModel != null)
+                        {
+                            await ClipboardModel.ClearAllAsync();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Clear history failed: {ex}");
+                    }
+                };
+                service.OpenSettingsRequested += (_, __) =>
+                {
+                    try
+                    {
+                        ShowMainWindow();
+                        m_window?.DispatcherQueue.TryEnqueue(() => m_window.NavigateRoot(typeof(LiuYun.Views.SettingsPage)));
+                        FireAndForget(ForceActivateMainWindowAsync(), nameof(ForceActivateMainWindowAsync));
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"Open settings failed: {ex}");
+                    }
+                };
+
+                // Initialize checked state from StartupService
+                try
+                {
+                    var startupService = new StartupService();
+                    var state = await startupService.GetStateAsync();
+                    service.SetStartupChecked(state.IsEnabled);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Failed to query startup state: {ex}");
+                }
 
                 _trayIconService = service;
             }

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -119,11 +119,10 @@ namespace LiuYun
                 DisposeTrayIcon();
                 Exit();
             };
-            m_window.Activate();
-            if (_isStartupLaunch)
-            {
-                HideWindowForStartupLaunch();
-            }
+            // Always start hidden by default; user can open via hotkey or tray icon.
+            // For startup launches we already treat as silent. For non-startup launches
+            // we also keep the window hidden and will show a brief tray notification.
+            HideWindowForStartupLaunch();
             FireAndForget(InitializeTrayIconAsync(), nameof(InitializeTrayIconAsync));
             StartSingleInstanceActivationListener();
 
@@ -391,13 +390,9 @@ namespace LiuYun
 
             CacheRootVisual();
 
-            if (_isStartupLaunch)
-            {
-                return;
-            }
-
-            ShowMainWindow();
-            await ForceActivateMainWindowAsync();
+            // For non-startup (manual) launches we intentionally keep the window hidden
+            // and rely on the tray/info tip and hotkeys to open the UI.
+            return;
         }
 
         private void HideWindowForStartupLaunch()
@@ -541,6 +536,18 @@ namespace LiuYun
                 }
 
                 _trayIconService = service;
+                // If this was a normal (non-startup) launch, inform the user the app is running minimized.
+                try
+                {
+                    if (!_isStartupLaunch)
+                    {
+                        service.ShowInfoTip("LiuYun", "LiuYun 正以最小化方式运行，可通过热键或单击任务栏图标打开");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"Failed to show startup info tip: {ex}");
+                }
             }
             catch (Exception ex)
             {
@@ -2011,8 +2018,8 @@ namespace LiuYun
             {
                 var diagnostics = HotkeyDiagnosticsService.RunDiagnostics();
                 message += $"=== 诊断信息 ==={Environment.NewLine}";
-                message += $"管理员权限: {(diagnostics.IsRunningAsAdmin ? "是" : "否")}{Environment.NewLine}";
-                message += $"系统剪贴板历史: {(diagnostics.ClipboardHistoryEnabled ? "已启用(占用Win+V)" : "已禁用")}{Environment.NewLine}{Environment.NewLine}";
+                message += "管理员权限: " + (diagnostics.IsRunningAsAdmin ? "是" : "否") + Environment.NewLine;
+                message += "系统剪贴板历史: " + (diagnostics.ClipboardHistoryEnabled ? "已启用(占用Win+V)" : "已禁用") + Environment.NewLine + Environment.NewLine;
             }
 
             message += "应用将继续运行，但快捷键在本次会话中不可用。";

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -276,6 +276,59 @@ namespace LiuYun
             }
         }
 
+        private static void MoveAppWindowNearCursor(AppWindow appWindow, POINT cursorPoint)
+        {
+            DisplayArea? displayArea = DisplayArea.GetFromPoint(
+                new PointInt32(cursorPoint.X, cursorPoint.Y),
+                DisplayAreaFallback.Primary);
+            RectInt32 workArea = displayArea?.WorkArea ?? new RectInt32(0, 0, 1920, 1080);
+
+            int windowWidth = appWindow.Size.Width > 0 ? appWindow.Size.Width : 520;
+            int windowHeight = appWindow.Size.Height > 0 ? appWindow.Size.Height : 520;
+
+            int minX = workArea.X;
+            int maxX = workArea.X + workArea.Width - windowWidth;
+            if (maxX < minX)
+            {
+                maxX = minX;
+            }
+
+            int rightX = cursorPoint.X + App.CursorPlacementOffsetPx;
+            int leftX = cursorPoint.X - App.CursorPlacementOffsetPx - windowWidth;
+            bool canPlaceRight = rightX <= maxX;
+            bool canPlaceLeft = leftX >= minX;
+
+            int targetX;
+            if (canPlaceRight)
+            {
+                targetX = rightX;
+            }
+            else if (canPlaceLeft)
+            {
+                targetX = leftX;
+            }
+            else
+            {
+                targetX = rightX;
+            }
+
+            int yAbove = cursorPoint.Y - App.CursorPlacementOffsetPx - windowHeight;
+            int yBelow = cursorPoint.Y + App.CursorPlacementOffsetPx;
+            int targetY = yAbove >= workArea.Y ? yAbove : yBelow;
+
+            int minY = workArea.Y;
+            int maxY = workArea.Y + workArea.Height - windowHeight;
+            if (maxY < minY)
+            {
+                maxY = minY;
+            }
+
+            targetX = Math.Clamp(targetX, minX, maxX);
+            targetY = Math.Clamp(targetY, minY, maxY);
+
+            appWindow.Move(new PointInt32(targetX, targetY));
+        }
+
         private void RootFrame_Navigated(object sender, Microsoft.UI.Xaml.Navigation.NavigationEventArgs e)
         {
             UpdateNavigationButtons(e.SourcePageType);
@@ -297,7 +350,8 @@ namespace LiuYun
                 return;
             }
 
-            if (PopupPlacementConfigService.GetMode() != PopupPlacementMode.FreeDrag)
+            PopupPlacementMode mode = PopupPlacementConfigService.GetMode();
+            if (mode != PopupPlacementMode.FreeDrag && mode != PopupPlacementMode.FollowMouse)
             {
                 return;
             }

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -515,7 +515,7 @@ namespace LiuYun
             }
         }
 
-        private void NavigateRoot(Type pageType)
+        internal void NavigateRoot(Type pageType)
         {
             if (rootFrame.Content?.GetType() == pageType)
             {

--- a/Models/ClipboardItem.cs
+++ b/Models/ClipboardItem.cs
@@ -98,7 +98,23 @@ namespace LiuYun.Models
             }
         }
 
-        public DateTime Timestamp { get; set; }
+        private DateTime _timestamp;
+
+        public DateTime Timestamp
+        {
+            get => _timestamp;
+            set
+            {
+                if (_timestamp == value)
+                {
+                    return;
+                }
+
+                _timestamp = value;
+                OnPropertyChanged(nameof(Timestamp));
+                OnPropertyChanged(nameof(DisplayTime));
+            }
+        }
 
         public string ContentHash
         {

--- a/Models/ClipboardItem.cs
+++ b/Models/ClipboardItem.cs
@@ -242,7 +242,13 @@ namespace LiuYun.Models
                 if (_weakImageSource != null &&
                     _weakImageSource.TryGetTarget(out BitmapImage? weakCachedImage))
                 {
-                    return weakCachedImage;
+                    // If bitmap source is reset (e.g., evicted from cache), refresh with a new image
+                    if (weakCachedImage.UriSource != null)
+                    {
+                        return weakCachedImage;
+                    }
+
+                    _weakImageSource = null;
                 }
 
                 if (!_thumbnailLoadingEnabled)

--- a/Services/ClipboardMonitorService.cs
+++ b/Services/ClipboardMonitorService.cs
@@ -260,6 +260,12 @@ namespace LiuYun.Services
                 return;
             }
 
+            if (App.Current is App app && app.IsClipboardMonitorSuppressed())
+            {
+                LogDiag("DROP_SUPPRESSED_PROGRAMMATIC_EVENT");
+                return;
+            }
+
             long nowTicks = DateTime.UtcNow.Ticks;
             long lastTicks = Interlocked.Read(ref _lastEventTimeTicks);
             long elapsedMs = (nowTicks - lastTicks) / TimeSpan.TicksPerMillisecond;

--- a/Services/DatabaseService.cs
+++ b/Services/DatabaseService.cs
@@ -656,5 +656,31 @@ namespace LiuYun.Services
                 : path + Path.DirectorySeparatorChar;
         }
 
+        public static bool UpdateClipboardItemTimestamp(int id, DateTime timestamp)
+        {
+            DbWriteLock.Wait();
+            try
+            {
+                using var connection = new SqliteConnection(ConnectionString);
+                connection.Open();
+
+                using var updateCmd = connection.CreateCommand();
+                updateCmd.CommandText = @"
+                    UPDATE ClipboardHistory
+                    SET Timestamp = $timestamp
+                    WHERE Id = $id";
+
+                updateCmd.Parameters.AddWithValue("$timestamp", timestamp.ToString("o"));
+                updateCmd.Parameters.AddWithValue("$id", id);
+
+                int rowsAffected = updateCmd.ExecuteNonQuery();
+                return rowsAffected > 0;
+            }
+            finally
+            {
+                DbWriteLock.Release();
+            }
+        }
+
     }
 }

--- a/Services/ImageCacheService.cs
+++ b/Services/ImageCacheService.cs
@@ -23,13 +23,18 @@ namespace LiuYun.Services
                 return;
             }
 
-            try
-            {
-                image.UriSource = null;
-            }
-            catch
-            {
-            }
+            // Keep the UriSource intact when releasing from cache.
+            // Clearing UriSource can cause already-bound Image controls to become blank.
+            //if (image.UriSource != null)
+            //{
+            //    try
+            //    {
+            //        image.UriSource = null;
+            //    }
+            //    catch
+            //    {
+            //    }
+            //}
         }
 
         public ImageCacheService(int maxCacheSize = 30)

--- a/Services/TrayIconService.cs
+++ b/Services/TrayIconService.cs
@@ -12,6 +12,7 @@ namespace LiuYun.Services
         private const int WM_LBUTTONDBLCLK = 0x0203;
         private const int WM_RBUTTONUP = 0x0205;
         private const int WM_CONTEXTMENU = 0x007B;
+        private const int WM_NULL = 0x0000;
         private const int WM_DESTROY = 0x0002;
 
         private const uint NIF_MESSAGE = 0x00000001;
@@ -25,8 +26,12 @@ namespace LiuYun.Services
         private const uint TPM_RIGHTALIGN = 0x00000008;
         private const uint TPM_RIGHTBUTTON = 0x00000002;
         private const uint TPM_RETURNCMD = 0x00000100;
+        private const uint MF_CHECKED = 0x00000008;
 
         private const int CommandExit = 1002;
+        private const int CommandToggleStartup = 1003;
+        private const int CommandClearHistory = 1004;
+        private const int CommandOpenSettings = 1005;
 
         private readonly IntPtr _windowHandle;
         private readonly ushort _iconId;
@@ -37,9 +42,13 @@ namespace LiuYun.Services
         private IntPtr _iconHandle;
         private IntPtr _menuHandle;
         private bool _disposed;
+        private bool _startupChecked;
 
         public event EventHandler? ShowRequested;
         public event EventHandler? ExitRequested;
+        public event EventHandler? ToggleStartupRequested;
+        public event EventHandler? ClearHistoryRequested;
+        public event EventHandler? OpenSettingsRequested;
 
         public TrayIconService(IntPtr windowHandle)
         {
@@ -103,7 +112,8 @@ namespace LiuYun.Services
 
         private void HandleTrayMessage(IntPtr lParam)
         {
-            int message = (int)lParam;
+            int raw = (int)lParam;
+            int message = raw & 0xFFFF;
             switch (message)
             {
                 case WM_LBUTTONUP:
@@ -119,15 +129,23 @@ namespace LiuYun.Services
 
         private void ShowContextMenu()
         {
-            if (_menuHandle == IntPtr.Zero)
+            // Recreate menu every time so dynamic checked state is reflected.
+            if (_menuHandle != IntPtr.Zero)
             {
-                _menuHandle = CreatePopupMenu();
-                AppendMenu(_menuHandle, 0, CommandExit, "退出");
+                DestroyMenu(_menuHandle);
+                _menuHandle = IntPtr.Zero;
             }
+
+            _menuHandle = CreatePopupMenu();
+            uint startupFlags = _startupChecked ? MF_CHECKED : 0u;
+            AppendMenu(_menuHandle, startupFlags, CommandToggleStartup, "开机自启动");
+            AppendMenu(_menuHandle, 0, CommandClearHistory, "清空历史记录");
+            AppendMenu(_menuHandle, 0, CommandOpenSettings, "设置");
+            AppendMenu(_menuHandle, 0, CommandExit, "退出");
 
             GetCursorPos(out POINT cursorPos);
 
-            IntPtr popupOwner = IsWindowVisible(_windowHandle) ? _windowHandle : GetDesktopWindow();
+            IntPtr popupOwner = _windowHandle;
             SetForegroundWindow(popupOwner);
             int commandId = TrackPopupMenu(
                 _menuHandle,
@@ -138,10 +156,36 @@ namespace LiuYun.Services
                 popupOwner,
                 IntPtr.Zero);
 
+            _ = PostMessage(popupOwner, (uint)WM_NULL, IntPtr.Zero, IntPtr.Zero);
+
             if (commandId == CommandExit)
             {
                 ExitRequested?.Invoke(this, EventArgs.Empty);
             }
+            else if (commandId == CommandToggleStartup)
+            {
+                ToggleStartupRequested?.Invoke(this, EventArgs.Empty);
+            }
+            else if (commandId == CommandClearHistory)
+            {
+                ClearHistoryRequested?.Invoke(this, EventArgs.Empty);
+            }
+            else if (commandId == CommandOpenSettings)
+            {
+                OpenSettingsRequested?.Invoke(this, EventArgs.Empty);
+            }
+
+            // Destroy the menu after use to ensure next open reflects current state
+            if (_menuHandle != IntPtr.Zero)
+            {
+                DestroyMenu(_menuHandle);
+                _menuHandle = IntPtr.Zero;
+            }
+        }
+
+        public void SetStartupChecked(bool isChecked)
+        {
+            _startupChecked = isChecked;
         }
 
         private static (IntPtr Handle, bool OwnsHandle) LoadApplicationIcon()
@@ -281,5 +325,7 @@ namespace LiuYun.Services
         [DllImport("user32.dll")]
         private static extern IntPtr GetDesktopWindow();
 
+        [DllImport("user32.dll")]
+        private static extern bool PostMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
     }
 }

--- a/Services/TrayIconService.cs
+++ b/Services/TrayIconService.cs
@@ -18,6 +18,8 @@ namespace LiuYun.Services
         private const uint NIF_MESSAGE = 0x00000001;
         private const uint NIF_ICON = 0x00000002;
         private const uint NIF_TIP = 0x00000004;
+        private const uint NIF_INFO = 0x00000010;
+        private const uint NIM_MODIFY = 0x00000001;
         private const uint NIM_ADD = 0x00000000;
         private const uint NIM_DELETE = 0x00000002;
         private const uint NIM_SETVERSION = 0x00000004;
@@ -186,6 +188,26 @@ namespace LiuYun.Services
         public void SetStartupChecked(bool isChecked)
         {
             _startupChecked = isChecked;
+        }
+
+        public void ShowInfoTip(string title, string message)
+        {
+            try
+            {
+                NOTIFYICONDATA data = CreateNotifyIconData();
+                // Ensure the info flag is set so balloon is displayed
+                data.uFlags |= NIF_INFO;
+                data.szInfoTitle = title ?? string.Empty;
+                data.szInfo = message ?? string.Empty;
+                data.dwInfoFlags = 0; // NIIF_NONE
+
+                // Modify the existing icon entry to display the balloon tip
+                Shell_NotifyIcon(NIM_MODIFY, ref data);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Failed to show info tip: {ex}");
+            }
         }
 
         private static (IntPtr Handle, bool OwnsHandle) LoadApplicationIcon()

--- a/Views/ClipboardPage.xaml
+++ b/Views/ClipboardPage.xaml
@@ -391,6 +391,7 @@
                 <ColumnDefinition Width="*"/>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
             </Grid.ColumnDefinitions>
 
             <AutoSuggestBox Grid.Column="0"
@@ -412,7 +413,22 @@
                 </AutoSuggestBox.Resources>
             </AutoSuggestBox>
 
-            <Button Grid.Column="1"
+            <StackPanel Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Spacing="6">
+                <Button x:Name="QuickFilterButton"
+                        Width="30"
+                        Height="30"
+                        Padding="0"
+                        Click="QuickFilterButton_Click"
+                        VerticalAlignment="Center"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="{StaticResource OverlayCornerRadius}">
+                    <FontIcon x:Name="QuickFilterGlyph" Glyph="&#xE71C;" FontSize="14" VerticalAlignment="Center"/>
+                </Button>
+            </StackPanel>
+
+        <Button Grid.Column="2"
                     Width="30"
                     Height="30"
                     Padding="0"
@@ -426,7 +442,7 @@
             </Button>
 
             <Button x:Name="SettingsActionButton"
-                    Grid.Column="2"
+                    Grid.Column="3"
                     Width="30"
                     Height="30"
                     Padding="0"

--- a/Views/ClipboardPage.xaml.cs
+++ b/Views/ClipboardPage.xaml.cs
@@ -56,6 +56,7 @@ namespace LiuYun.Views
         private bool _updateBannerSubscribed;
         private bool _isRefreshingFilteredItems;
         private bool _pendingRefreshAfterCurrentPass;
+        private double? _savedClipboardScrollOffset = null;
         private readonly List<ClipboardItem> _orderedFilteredItems = new List<ClipboardItem>();
         private static readonly bool ManualRepeaterSourceToggleEnabled = false;
 
@@ -621,6 +622,9 @@ namespace LiuYun.Views
         {
             try
             {
+                // prevent other flows from forcing selection to first on next refresh
+                _forceSelectFirstOnNextRefresh = false;
+
                 await Task.Run(() => DatabaseService.DeleteFavoriteClipboardItem(favoriteItem.Id));
                 TryDeleteFavoriteImageFile(favoriteItem.ImagePath);
 
@@ -629,11 +633,37 @@ namespace LiuYun.Views
                     favoriteItem.ClearImageCache();
                 }
 
+                // record neighbor selection to preserve viewport
+                int filteredIndex = -1;
+                ClipboardItem? neighborSelection = null;
+                try
+                {
+                    if (FilteredItems != null)
+                    {
+                        filteredIndex = FilteredItems.IndexOf(favoriteItem);
+                        if (filteredIndex >= 0)
+                        {
+                            if (filteredIndex < FilteredItems.Count - 1)
+                            {
+                                neighborSelection = FilteredItems[filteredIndex + 1];
+                            }
+                            else if (filteredIndex - 1 >= 0)
+                            {
+                                neighborSelection = FilteredItems[filteredIndex - 1];
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    // ignore concurrency issues when reading FilteredItems
+                }
+
                 _favoriteItems.Remove(favoriteItem);
 
                 if (ReferenceEquals(_keyboardSelectedItem, favoriteItem))
                 {
-                    SetKeyboardSelectedItem(null);
+                    SetKeyboardSelectedItem(neighborSelection);
                 }
 
                 if (refreshList && _currentListMode == ClipboardListMode.Favorite)
@@ -827,6 +857,9 @@ namespace LiuYun.Views
                 return;
             }
 
+            // save current scroll offset so we can attempt to restore it after incremental updates
+            SaveClipboardScrollOffsetSnapshot();
+
             try
             {
                 _pendingRefreshWhileHidden = false;
@@ -881,6 +914,9 @@ namespace LiuYun.Views
 
                 OnPropertyChanged(nameof(HistoryEmptyHintVisibility));
                 ApplyKeyboardSelectionAfterRefresh();
+
+                // try to restore saved scroll offset if present; otherwise clamp to valid range
+                TryRestoreClipboardScrollOffsetSnapshot();
                 ClampClipboardScrollOffset();
             }
             finally
@@ -1626,6 +1662,54 @@ namespace LiuYun.Views
             });
         }
 
+        private void SaveClipboardScrollOffsetSnapshot()
+        {
+            try
+            {
+                if (ClipboardScrollViewer != null)
+                {
+                    _savedClipboardScrollOffset = ClipboardScrollViewer.VerticalOffset;
+                }
+                else
+                {
+                    _savedClipboardScrollOffset = null;
+                }
+            }
+            catch
+            {
+                _savedClipboardScrollOffset = null;
+            }
+        }
+
+        private void TryRestoreClipboardScrollOffsetSnapshot()
+        {
+            if (_savedClipboardScrollOffset == null || ClipboardScrollViewer == null || DispatcherQueue == null)
+            {
+                _savedClipboardScrollOffset = null;
+                return;
+            }
+
+            double targetOffset = Math.Clamp(_savedClipboardScrollOffset.Value, 0, ClipboardScrollViewer.ScrollableHeight);
+
+            // perform restore after layout passes to ensure ScrollableHeight is accurate
+            _ = DispatcherQueue.TryEnqueue(() =>
+            {
+                try
+                {
+                    ClipboardItemsRepeater?.UpdateLayout();
+                    ClipboardScrollViewer.UpdateLayout();
+                    double clamped = Math.Clamp(targetOffset, 0, ClipboardScrollViewer.ScrollableHeight);
+                    ClipboardScrollViewer.ChangeView(null, clamped, null, true);
+                }
+                catch
+                {
+                    // ignore failures
+                }
+            });
+
+            _savedClipboardScrollOffset = null;
+        }
+
         private void ClampClipboardScrollOffsetCore()
         {
             if (ClipboardScrollViewer == null)
@@ -1895,6 +1979,34 @@ namespace LiuYun.Views
                     }
                 }
 
+
+                // Record neighbor selection to preserve viewport after removal.
+                int filteredIndex = -1;
+                ClipboardItem? neighborSelection = null;
+                try
+                {
+                    if (FilteredItems != null)
+                    {
+                        filteredIndex = FilteredItems.IndexOf(historyItem);
+                        if (filteredIndex >= 0)
+                        {
+                            // prefer next item; if none, pick previous
+                            if (filteredIndex < FilteredItems.Count - 1)
+                            {
+                                neighborSelection = FilteredItems[filteredIndex + 1];
+                            }
+                            else if (filteredIndex - 1 >= 0)
+                            {
+                                neighborSelection = FilteredItems[filteredIndex - 1];
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    // ignore any concurrency issues reading FilteredItems
+                }
+
                 bool removedFromCollection = clipboardModel.Items.Remove(historyItem);
                 if (!removedFromCollection && historyItem.Id > 0)
                 {
@@ -1906,19 +2018,13 @@ namespace LiuYun.Views
                     }
                 }
 
+                // If the removed item was the keyboard-selected one, try to select a neighbor to keep viewport stable.
                 if (ReferenceEquals(_keyboardSelectedItem, historyItem))
                 {
-                    SetKeyboardSelectedItem(null);
+                    SetKeyboardSelectedItem(neighborSelection);
                 }
 
-                if (_keyboardSelectedItem == null)
-                {
-                    _forceSelectFirstOnNextRefresh = true;
-                }
-
-                if (refreshList &&
-                    _currentListMode == ClipboardListMode.History &&
-                    !removedFromCollection)
+                if (refreshList && _currentListMode == ClipboardListMode.History)
                 {
                     RefreshFilteredItems();
                 }

--- a/Views/ClipboardPage.xaml.cs
+++ b/Views/ClipboardPage.xaml.cs
@@ -1977,6 +1977,11 @@ namespace LiuYun.Views
                     }
                 }
 
+                if (App.Current is App currentApp)
+                {
+                    currentApp.SuppressClipboardMonitorFor(TimeSpan.FromMilliseconds(1000));
+                }
+
                 var tcs = new TaskCompletionSource<bool>();
                 bool enqueued = DispatcherQueue.TryEnqueue(() =>
                 {

--- a/Views/ClipboardPage.xaml.cs
+++ b/Views/ClipboardPage.xaml.cs
@@ -1169,6 +1169,8 @@ namespace LiuYun.Views
                 return;
             }
 
+            PromoteClipboardItem(selected);
+
             _isSubmittingKeyboardSelection = true;
             try
             {
@@ -1352,6 +1354,45 @@ namespace LiuYun.Views
             }
         }
 
+        private void PromoteClipboardItem(ClipboardItem item)
+        {
+            if (item == null)
+            {
+                return;
+            }
+
+            DateTime now = DateTime.Now;
+
+            if (_currentListMode == ClipboardListMode.History && item.Id > 0)
+            {
+                item.Timestamp = now;
+                bool updated = DatabaseService.UpdateClipboardItemTimestamp(item.Id, now);
+                if (updated)
+                {
+                    RefreshFilteredItems();
+                }
+
+                return;
+            }
+
+            if (_currentListMode == ClipboardListMode.Favorite)
+            {
+                var historyMatch = clipboardModel?.Items?.FirstOrDefault(x =>
+                    x.ContentType == item.ContentType &&
+                    string.Equals(x.ContentHash, item.ContentHash, StringComparison.Ordinal));
+
+                if (historyMatch != null && historyMatch.Id > 0)
+                {
+                    historyMatch.Timestamp = now;
+                    bool updated = DatabaseService.UpdateClipboardItemTimestamp(historyMatch.Id, now);
+                    if (updated)
+                    {
+                        RefreshFilteredItems();
+                    }
+                }
+            }
+        }
+
         private async void ClipboardCard_Tapped(object sender, TappedRoutedEventArgs e)
         {
             e.Handled = true;
@@ -1363,6 +1404,8 @@ namespace LiuYun.Views
 
             if (sender is Border border && border.Tag is ClipboardItem item)
             {
+                PromoteClipboardItem(item);
+
                 _isSubmittingKeyboardSelection = true;
                 try
                 {

--- a/Views/ClipboardPage.xaml.cs
+++ b/Views/ClipboardPage.xaml.cs
@@ -138,6 +138,8 @@ namespace LiuYun.Views
             _categoryFilter = ClipboardFilterState.Current;
             _filterStartTime = ClipboardTimeFilterState.StartTime;
             _filterEndTime = ClipboardTimeFilterState.EndTime;
+            // sync quick category dropdown selection
+            UpdateQuickFilterButtonVisual(_categoryFilter);
         }
 
         public void OnHostWindowVisibilityChanged(bool isVisible)
@@ -394,6 +396,18 @@ namespace LiuYun.Views
             OnPropertyChanged(nameof(ListModeToggleTooltip));
             OnPropertyChanged(nameof(FavoriteQuickButtonText));
             OnPropertyChanged(nameof(HistoryEmptyHintVisibility));
+            // show filter button only in history mode
+            try
+            {
+                if (QuickFilterButton != null)
+                {
+                    QuickFilterButton.Visibility = _currentListMode == ClipboardListMode.History ? Visibility.Visible : Visibility.Collapsed;
+                }
+            }
+            catch
+            {
+                // ignore if UI not ready
+            }
         }
 
         private void UpdateInlineFavoriteButtonText(Border deleteButton)
@@ -740,7 +754,27 @@ namespace LiuYun.Views
             {
                 RefreshFilteredItems();
                 UpdateCategoryFilterTooltip();
+                UpdateQuickFilterButtonVisual(filter);
             });
+        }
+
+        private void UpdateQuickFilterButtonVisual(ClipboardCategoryFilter filter)
+        {
+            try
+            {
+                if (QuickFilterGlyph != null && QuickFilterButton != null)
+                {
+                    var glyph = GetCategoryGlyph(filter);
+                    QuickFilterGlyph.Glyph = string.IsNullOrEmpty(glyph) ? "\uE71C" : glyph;
+                    QuickFilterButton.Opacity = filter == ClipboardCategoryFilter.All ? 1.0 : 0.95;
+                    // tooltip
+                    var label = GetCategoryFilterLabel(filter);
+                    ToolTipService.SetToolTip(QuickFilterButton, $"筛选: {label}");
+                }
+            }
+            catch
+            {
+            }
         }
 
         private void ClipboardTimeFilterState_FilterChanged(object? sender, EventArgs e)
@@ -1114,6 +1148,134 @@ namespace LiuYun.Views
         {
         }
 
+        private void QuickFilterButton_Click(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var flyout = new Flyout();
+
+                // compute counts snapshot
+                var itemsSnapshot = clipboardModel?.Items ?? Enumerable.Empty<ClipboardItem>();
+                int cnt_all = itemsSnapshot.Count();
+                int cnt_text = itemsSnapshot.Count(i => i.ContentType == ClipboardContentType.Text);
+                int cnt_code = itemsSnapshot.Count(i => i.SemanticType == ClipboardSemanticType.Code);
+                int cnt_json = itemsSnapshot.Count(i => i.SemanticType == ClipboardSemanticType.Json);
+                int cnt_longNumber = itemsSnapshot.Count(i => i.SemanticType == ClipboardSemanticType.LongNumber);
+                int cnt_image = itemsSnapshot.Count(i => i.SemanticType == ClipboardSemanticType.Image);
+                int cnt_file = itemsSnapshot.Count(i => i.SemanticType == ClipboardSemanticType.FilePath);
+                int cnt_link = itemsSnapshot.Count(i => i.SemanticType == ClipboardSemanticType.Link);
+                int cnt_email = itemsSnapshot.Count(i => i.SemanticType == ClipboardSemanticType.Email);
+
+                var panel = new StackPanel { Orientation = Orientation.Vertical };
+
+                void addItem(ClipboardCategoryFilter f, string label)
+                {
+                    string suffix = f switch
+                    {
+                        ClipboardCategoryFilter.All => $" ({cnt_all})",
+                        ClipboardCategoryFilter.Text => $" ({cnt_text})",
+                        ClipboardCategoryFilter.Code => $" ({cnt_code})",
+                        ClipboardCategoryFilter.Json => $" ({cnt_json})",
+                        ClipboardCategoryFilter.LongNumber => $" ({cnt_longNumber})",
+                        ClipboardCategoryFilter.Image => $" ({cnt_image})",
+                        ClipboardCategoryFilter.File => $" ({cnt_file})",
+                        ClipboardCategoryFilter.Link => $" ({cnt_link})",
+                        ClipboardCategoryFilter.Email => $" ({cnt_email})",
+                        _ => string.Empty,
+                    };
+
+                    var item = new RadioButton { Tag = f, GroupName = "QuickFilterGroup" };
+
+                    // build content: Grid with icon | label | count (right-aligned)
+                    var grid = new Grid();
+                    grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+                    grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                    grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+                    var iconGlyph = GetCategoryGlyph(f);
+                    if (!string.IsNullOrEmpty(iconGlyph))
+                    {
+                        var iconEl = new FontIcon { Glyph = iconGlyph, FontSize = 12, VerticalAlignment = VerticalAlignment.Center };
+                        Grid.SetColumn(iconEl, 0);
+                        grid.Children.Add(iconEl);
+                    }
+
+                    var labelText = new TextBlock { Text = label, VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(8, 0, 0, 0) };
+                    Grid.SetColumn(labelText, 1);
+                    grid.Children.Add(labelText);
+
+                    var countText = new TextBlock { Text = suffix, VerticalAlignment = VerticalAlignment.Center, Margin = new Thickness(12, 0, 0, 0) };
+                    try
+                    {
+                        if (Application.Current != null && Application.Current.Resources.ContainsKey("TextFillColorSecondaryBrush"))
+                        {
+                            countText.Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["TextFillColorSecondaryBrush"];
+                        }
+                    }
+                    catch
+                    {
+                        // ignore resource lookup failures
+                    }
+                    Grid.SetColumn(countText, 2);
+                    grid.Children.Add(countText);
+
+                    item.Content = grid;
+                    item.IsChecked = ClipboardFilterState.Current == f;
+                    item.Checked += (_, __) =>
+                    {
+                        try
+                        {
+                            ClipboardFilterState.Current = f;
+                            flyout.Hide();
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.WriteLine($"QuickFilter selection failed: {ex.Message}");
+                        }
+                    };
+
+                    panel.Children.Add(item);
+                }
+
+                addItem(ClipboardCategoryFilter.All, "全部");
+                addItem(ClipboardCategoryFilter.Text, "文本");
+                addItem(ClipboardCategoryFilter.Image, "图片");
+                addItem(ClipboardCategoryFilter.Link, "链接");
+                addItem(ClipboardCategoryFilter.Email, "邮箱");
+                addItem(ClipboardCategoryFilter.File, "文件");
+                addItem(ClipboardCategoryFilter.Code, "代码");
+                addItem(ClipboardCategoryFilter.Json, "JSON");
+                addItem(ClipboardCategoryFilter.LongNumber, "数字");
+
+                flyout.Content = panel;
+                if (sender is FrameworkElement fe)
+                {
+                    flyout.ShowAt(fe);
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"QuickFilterButton_Click failed: {ex.Message}");
+            }
+        }
+
+        private static string GetCategoryGlyph(ClipboardCategoryFilter f)
+        {
+            return f switch
+            {
+                ClipboardCategoryFilter.All => "\uE71D",
+                ClipboardCategoryFilter.Text => "\uE8C8",
+                ClipboardCategoryFilter.Image => "\uE91B",
+                ClipboardCategoryFilter.Link => "\uE71B",
+                ClipboardCategoryFilter.Email => "\uE715",
+                ClipboardCategoryFilter.File => "\uE8B7",
+                ClipboardCategoryFilter.Code => "\uE943",
+                ClipboardCategoryFilter.Json => "\uE943",
+                ClipboardCategoryFilter.LongNumber => "\uE8C8",
+                _ => string.Empty,
+            };
+        }
+
         private async void ClipboardPage_KeyDown(object sender, KeyRoutedEventArgs e)
         {
             if (!_isHostWindowVisible || _isLoading || _isSubmittingKeyboardSelection)
@@ -1228,7 +1390,7 @@ namespace LiuYun.Views
                 timeText = $"<={_filterEndTime:MM-dd}";
             }
 
-            ToolTipService.SetToolTip(SettingsActionButton, $"分类: {categoryText} | 时间: {timeText}");
+            ToolTipService.SetToolTip(SettingsActionButton, "分类: " + categoryText + " | 时间: " + timeText);
         }
 
         private async void ClipboardPage_Loaded(object sender, RoutedEventArgs e)

--- a/Views/NavigationHubPage.xaml
+++ b/Views/NavigationHubPage.xaml
@@ -95,7 +95,7 @@
                             <RowDefinition Height="Auto"/>
                         </Grid.RowDefinitions>
 
-                        <Button Grid.Row="0" Grid.Column="0" Style="{StaticResource HubActionButtonStyle}" Tag="All" Click="CategoryFilterButton_Click">
+                        <Button x:Name="AllCategoryButton" Grid.Row="0" Grid.Column="0" Style="{StaticResource HubActionButtonStyle}" Tag="All" Click="CategoryFilterButton_Click">
                             <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <FontIcon Glyph="&#xE71D;" FontSize="12"/>
                                 <TextBlock Text="全部" Style="{StaticResource CategoryLabelTextStyle}" VerticalAlignment="Center"/>
@@ -104,7 +104,7 @@
                                 </Border>
                             </StackPanel>
                         </Button>
-                        <Button Grid.Row="0" Grid.Column="1" Style="{StaticResource HubActionButtonStyle}" Tag="Text" Click="CategoryFilterButton_Click">
+                        <Button x:Name="TextCategoryButton" Grid.Row="0" Grid.Column="1" Style="{StaticResource HubActionButtonStyle}" Tag="Text" Click="CategoryFilterButton_Click">
                             <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <FontIcon Glyph="&#xE8C8;" FontSize="12"/>
                                 <TextBlock Text="文本" Style="{StaticResource CategoryLabelTextStyle}" VerticalAlignment="Center"/>
@@ -113,7 +113,7 @@
                                 </Border>
                             </StackPanel>
                         </Button>
-                        <Button Grid.Row="0" Grid.Column="2" Style="{StaticResource HubActionButtonStyle}" Tag="Code" Click="CategoryFilterButton_Click">
+                        <Button x:Name="CodeCategoryButton" Grid.Row="0" Grid.Column="2" Style="{StaticResource HubActionButtonStyle}" Tag="Code" Click="CategoryFilterButton_Click">
                             <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <FontIcon Glyph="&#xE943;" FontSize="12"/>
                                 <TextBlock Text="代码" Style="{StaticResource CategoryLabelTextStyle}" VerticalAlignment="Center"/>
@@ -123,7 +123,7 @@
                             </StackPanel>
                         </Button>
 
-                        <Button Grid.Row="1" Grid.Column="0" Style="{StaticResource HubActionButtonStyle}" Tag="Json" Click="CategoryFilterButton_Click">
+                        <Button x:Name="JsonCategoryButton" Grid.Row="1" Grid.Column="0" Style="{StaticResource HubActionButtonStyle}" Tag="Json" Click="CategoryFilterButton_Click">
                             <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <FontIcon Glyph="&#xE943;" FontSize="12"/>
                                 <TextBlock Text="JSON" Style="{StaticResource CategoryLabelTextStyle}" VerticalAlignment="Center"/>
@@ -132,7 +132,7 @@
                                 </Border>
                             </StackPanel>
                         </Button>
-                        <Button Grid.Row="1" Grid.Column="1" Style="{StaticResource HubActionButtonStyle}" Tag="LongNumber" Click="CategoryFilterButton_Click">
+                        <Button x:Name="LongNumberCategoryButton" Grid.Row="1" Grid.Column="1" Style="{StaticResource HubActionButtonStyle}" Tag="LongNumber" Click="CategoryFilterButton_Click">
                             <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <FontIcon Glyph="&#xE8C8;" FontSize="12"/>
                                 <TextBlock Text="数字" Style="{StaticResource CategoryLabelTextStyle}" VerticalAlignment="Center"/>
@@ -141,7 +141,7 @@
                                 </Border>
                             </StackPanel>
                         </Button>
-                        <Button Grid.Row="1" Grid.Column="2" Style="{StaticResource HubActionButtonStyle}" Tag="Image" Click="CategoryFilterButton_Click">
+                        <Button x:Name="ImageCategoryButton" Grid.Row="1" Grid.Column="2" Style="{StaticResource HubActionButtonStyle}" Tag="Image" Click="CategoryFilterButton_Click">
                             <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <FontIcon Glyph="&#xE91B;" FontSize="12"/>
                                 <TextBlock Text="图片" Style="{StaticResource CategoryLabelTextStyle}" VerticalAlignment="Center"/>
@@ -151,7 +151,7 @@
                             </StackPanel>
                         </Button>
 
-                        <Button Grid.Row="2" Grid.Column="0" Style="{StaticResource HubActionButtonStyle}" Tag="File" Click="CategoryFilterButton_Click">
+                        <Button x:Name="FileCategoryButton" Grid.Row="2" Grid.Column="0" Style="{StaticResource HubActionButtonStyle}" Tag="File" Click="CategoryFilterButton_Click">
                             <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <FontIcon Glyph="&#xE8B7;" FontSize="12"/>
                                 <TextBlock Text="文件" Style="{StaticResource CategoryLabelTextStyle}" VerticalAlignment="Center"/>
@@ -160,7 +160,7 @@
                                 </Border>
                             </StackPanel>
                         </Button>
-                        <Button Grid.Row="2" Grid.Column="1" Style="{StaticResource HubActionButtonStyle}" Tag="Link" Click="CategoryFilterButton_Click">
+                        <Button x:Name="LinkCategoryButton" Grid.Row="2" Grid.Column="1" Style="{StaticResource HubActionButtonStyle}" Tag="Link" Click="CategoryFilterButton_Click">
                             <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <FontIcon Glyph="&#xE71B;" FontSize="12"/>
                                 <TextBlock Text="链接" Style="{StaticResource CategoryLabelTextStyle}" VerticalAlignment="Center"/>
@@ -169,7 +169,7 @@
                                 </Border>
                             </StackPanel>
                         </Button>
-                        <Button Grid.Row="2" Grid.Column="2" Style="{StaticResource HubActionButtonStyle}" Tag="Email" Click="CategoryFilterButton_Click">
+                        <Button x:Name="EmailCategoryButton" Grid.Row="2" Grid.Column="2" Style="{StaticResource HubActionButtonStyle}" Tag="Email" Click="CategoryFilterButton_Click">
                             <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center" VerticalAlignment="Center">
                                 <FontIcon Glyph="&#xE715;" FontSize="12"/>
                                 <TextBlock Text="邮箱" Style="{StaticResource CategoryLabelTextStyle}" VerticalAlignment="Center"/>
@@ -228,7 +228,7 @@
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
 
-                            <Button Grid.Row="0"
+                            <Button x:Name="QuickTodayButton" Grid.Row="0"
                                     Grid.Column="0"
                                     Content="今天"
                                     Padding="10,6"
@@ -237,7 +237,7 @@
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     Click="QuickTodayFilterButton_Click"/>
-                            <Button Grid.Row="0"
+                            <Button x:Name="QuickFourteenDaysButton" Grid.Row="0"
                                     Grid.Column="1"
                                     Content="14天"
                                     Padding="10,6"
@@ -246,7 +246,7 @@
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     Click="QuickFourteenDaysFilterButton_Click"/>
-                            <Button Grid.Row="1"
+                            <Button x:Name="QuickSevenDaysButton" Grid.Row="1"
                                     Grid.Column="0"
                                     Content="7天"
                                     Padding="10,6"
@@ -255,7 +255,7 @@
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
                                     Click="QuickSevenDaysFilterButton_Click"/>
-                            <Button Grid.Row="1"
+                            <Button x:Name="QuickAllButton" Grid.Row="1"
                                     Grid.Column="1"
                                     Content="全部"
                                     Padding="10,6"

--- a/Views/NavigationHubPage.xaml.cs
+++ b/Views/NavigationHubPage.xaml.cs
@@ -33,9 +33,13 @@ namespace LiuYun.Views
 
             AttachClipboardItemsSubscription();
             RefreshCategoryCounts();
-            // subscribe to global filter changes so status line stays in sync
+            // Ensure UI reflects current global category and time filters
             ClipboardFilterState.FilterChanged += ClipboardFilterState_FilterChanged;
-            // initialize status
+            UpdateActiveCategoryVisual(ClipboardFilterState.Current);
+
+            ClipboardTimeFilterState.FilterChanged += ClipboardTimeFilterState_FilterChanged_Nav;
+            UpdateActiveTimeVisual(ClipboardTimeFilterState.StartTime, ClipboardTimeFilterState.EndTime);
+
             UpdateStatusTextFromFilter();
         }
 
@@ -44,17 +48,32 @@ namespace LiuYun.Views
             DetachClipboardItemsSubscription();
             // unsubscribe from global filter changes
             ClipboardFilterState.FilterChanged -= ClipboardFilterState_FilterChanged;
+            ClipboardTimeFilterState.FilterChanged -= ClipboardTimeFilterState_FilterChanged_Nav;
             base.OnNavigatedFrom(e);
         }
 
         private void ClipboardFilterState_FilterChanged(object? sender, ClipboardCategoryFilter filter)
         {
+            // If no dispatcher queue is available, nothing we can do safely.
             if (DispatcherQueue == null)
             {
                 return;
             }
 
-            _ = DispatcherQueue.TryEnqueue(() => UpdateStatusTextFromFilter());
+            // If we're already on the UI thread, update both visual and status immediately.
+            if (DispatcherQueue.HasThreadAccess)
+            {
+                UpdateActiveCategoryVisual(filter);
+                UpdateStatusTextFromFilter();
+                return;
+            }
+
+            // Otherwise, enqueue a single action that updates both to avoid multiple dispatches.
+            _ = DispatcherQueue.TryEnqueue(() =>
+            {
+                UpdateActiveCategoryVisual(filter);
+                UpdateStatusTextFromFilter();
+            });
         }
 
         private void UpdateStatusTextFromFilter()
@@ -69,6 +88,115 @@ namespace LiuYun.Views
             catch
             {
             }
+        }
+
+        private void ClipboardTimeFilterState_FilterChanged_Nav(object? sender, EventArgs e)
+        {
+            if (DispatcherQueue == null || DispatcherQueue.HasThreadAccess)
+            {
+                UpdateActiveTimeVisual(ClipboardTimeFilterState.StartTime, ClipboardTimeFilterState.EndTime);
+                return;
+            }
+
+            _ = DispatcherQueue.TryEnqueue(() => UpdateActiveTimeVisual(ClipboardTimeFilterState.StartTime, ClipboardTimeFilterState.EndTime));
+        }
+
+        private void UpdateActiveCategoryVisual(ClipboardCategoryFilter filter)
+        {
+            // List all buttons for easy iteration
+            var allButtons = new Button?[]
+            {
+                AllCategoryButton,
+                TextCategoryButton,
+                CodeCategoryButton,
+                JsonCategoryButton,
+                LongNumberCategoryButton,
+                ImageCategoryButton,
+                FileCategoryButton,
+                LinkCategoryButton,
+                EmailCategoryButton
+            };
+
+            // Dim all buttons first
+            foreach (var btn in allButtons)
+            {
+                if (btn == null)
+                {
+                    continue;
+                }
+
+                btn.Opacity = 0.7;
+            }
+
+            // Determine which button corresponds to the filter and highlight it
+            Button? selected = filter switch
+            {
+                ClipboardCategoryFilter.All => AllCategoryButton,
+                ClipboardCategoryFilter.Text => TextCategoryButton,
+                ClipboardCategoryFilter.Code => CodeCategoryButton,
+                ClipboardCategoryFilter.Json => JsonCategoryButton,
+                ClipboardCategoryFilter.LongNumber => LongNumberCategoryButton,
+                ClipboardCategoryFilter.Image => ImageCategoryButton,
+                ClipboardCategoryFilter.File => FileCategoryButton,
+                ClipboardCategoryFilter.Link => LinkCategoryButton,
+                ClipboardCategoryFilter.Email => EmailCategoryButton,
+                _ => AllCategoryButton
+            };
+
+            if (selected != null)
+            {
+                selected.Opacity = 1.0;
+            }
+        }
+
+        private void UpdateActiveTimeVisual(DateTime? start, DateTime? end)
+        {
+            // Dim all quick buttons and date pickers by default
+            var quickButtons = new Button?[] { QuickTodayButton, QuickSevenDaysButton, QuickFourteenDaysButton, QuickAllButton };
+            foreach (var b in quickButtons)
+            {
+                if (b != null) b.Opacity = 0.7;
+            }
+
+            if (StartDatePicker != null) StartDatePicker.Opacity = 0.7;
+            if (EndDatePicker != null) EndDatePicker.Opacity = 0.7;
+
+            // Decide which quick filter this matches (Today / 7 / 14 / All) or custom
+            if (!start.HasValue && !end.HasValue)
+            {
+                if (QuickAllButton != null) QuickAllButton.Opacity = 1.0;
+                return;
+            }
+
+            DateTime today = DateTime.Today;
+            // Normalize boundaries produced by BuildStartBoundary/BuildEndBoundary
+            DateTime? s = start?.Date;
+            DateTime? e = end?.Date;
+
+            if (s.HasValue && e.HasValue)
+            {
+                if (s.Value == today && e.Value == today)
+                {
+                    if (QuickTodayButton != null) QuickTodayButton.Opacity = 1.0;
+                    return;
+                }
+
+                if (s.Value == today.AddDays(-6) && e.Value == today)
+                {
+                    if (QuickSevenDaysButton != null) QuickSevenDaysButton.Opacity = 1.0;
+                    return;
+                }
+
+                if (s.Value == today.AddDays(-13) && e.Value == today)
+                {
+                    if (QuickFourteenDaysButton != null) QuickFourteenDaysButton.Opacity = 1.0;
+                    return;
+                }
+            }
+
+            // Custom range: highlight the date pickers
+            if (StartDatePicker != null) StartDatePicker.Opacity = 1.0;
+            if (EndDatePicker != null) EndDatePicker.Opacity = 1.0;
         }
 
         private void BackButton_Click(object sender, RoutedEventArgs e)

--- a/Views/NavigationHubPage.xaml.cs
+++ b/Views/NavigationHubPage.xaml.cs
@@ -33,12 +33,42 @@ namespace LiuYun.Views
 
             AttachClipboardItemsSubscription();
             RefreshCategoryCounts();
+            // subscribe to global filter changes so status line stays in sync
+            ClipboardFilterState.FilterChanged += ClipboardFilterState_FilterChanged;
+            // initialize status
+            UpdateStatusTextFromFilter();
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)
         {
             DetachClipboardItemsSubscription();
+            // unsubscribe from global filter changes
+            ClipboardFilterState.FilterChanged -= ClipboardFilterState_FilterChanged;
             base.OnNavigatedFrom(e);
+        }
+
+        private void ClipboardFilterState_FilterChanged(object? sender, ClipboardCategoryFilter filter)
+        {
+            if (DispatcherQueue == null)
+            {
+                return;
+            }
+
+            _ = DispatcherQueue.TryEnqueue(() => UpdateStatusTextFromFilter());
+        }
+
+        private void UpdateStatusTextFromFilter()
+        {
+            try
+            {
+                var category = ClipboardFilterState.Current;
+                string categoryText = GetCategoryFilterLabel(category);
+
+                StatusText.Text = $"已应用筛选：分类 {categoryText}";
+            }
+            catch
+            {
+            }
         }
 
         private void BackButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
- [x] 修复剪贴板条目粘贴后的数据库更新行为
- [x] 使窗口在鼠标跟随模式下也可自由移动
- [x] 修复托盘图标的点击响应，添加开机自启动、清理记录和设置的托盘菜单项
- [x] 模仿其他剪贴板应用的启动行为：静默打开并推送系统消息通知
- [x] 优化导航页面的筛选状态的视觉反馈
- [x] 将实用度和使用频率较高的分类筛选添加至主界面，只放在二级界面对于这种高频操作的用户体验不友好
  时间筛选的用户使用频率不会很高，无需添加至主界面，保留原始行为
- [x] 避免监控自身程序的复制行为（会导致图片条目粘贴后重复出现）
- [x] 删除条目即时更新界面并保持滚动位置
- [x] 从缓存中释放图像时保留 UriSource。修复图片回滚浏览时缩略图消失的问题

编辑：本地推送时似乎自动进行了一些格式化处理导致 github 上的 diff 多了很多内容

Close #1
Close #2
Close #3
Close #4
Close #5